### PR TITLE
feat: Add `solc` patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ docs/
 
 # Patched `forge` bin
 bin/forge
+# Patched `solc` bin
+bin/solc

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lib/solady"]
 	path = lib/solady
 	url = https://github.com/vectorized/solady
+[submodule "solidity"]
+	path = solidity
+	url = https://github.com/clabby/solidity

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+all: build-forge-patch build-solc-patch
+
 .PHONY: build-forge-patch
 build-forge-patch:
 	@echo "Building forge patch..."
@@ -5,7 +7,19 @@ build-forge-patch:
 		cargo build --bin forge --release && \
 		mkdir -p ../bin && \
 		cp target/release/forge ../bin/forge
-	@echo "Done, patched forge binary is located in `bin/forge` relative to the project root"
+	@echo "Done, patched forge binary is located at `bin/forge` relative to the project root"
+
+.PHONY: build-solc-patch
+build-solc-patch:
+	@echo "Building solc patch..."
+	@cd solidity && \
+		mkdir -p build && \
+		cd build && \
+		cmake .. && \
+		make && \
+		mkdir -p ../../bin && \
+		cp solc/solc ../../bin/solc
+	@echo "Done, patched solc binary is located at `bin/solc` relative to the project root"
 
 .PHONY: install-huff
 install-huff:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `eip-3074-foundry`
 
-This repository contains a patched version of [`foundry`][foundry], integrated with a fork of [`revm`][revm] / [`ethers-rs`][ethers-rs], that supports
+This repository contains patched versions of [`foundry`][foundry] & [the `solidity` compiler][solc], integrated with patches to [`revm`][revm] / [`ethers-rs`][ethers-rs], that support
 the [EIP-3074][eip-3074] opcodes (`AUTH` & `AUTHCALL`).
 
 ## Patches
@@ -8,20 +8,32 @@ the [EIP-3074][eip-3074] opcodes (`AUTH` & `AUTHCALL`).
 - `revm` patch: https://github.com/clabby/revm/pull/1
 - `ethers-rs` patch: https://github.com/clabby/ethers-rs/tree/cl/call-type-3074
 - `foundry` patch: https://github.com/clabby/foundry/tree/cl/eip-3074
+- `solc` patch: https://github.com/clabby/solidity/tree/cl/eip-3074
 
 ## Usage
 
 **Building `forge`**
 
-First, build the patched version of `foundry`:
+First, build the patched version of `foundry` (this will take a while):
 
 ```sh
-git submodule update --init --recursive && make build-forge-patch
+git submodule update --init --recursive && \
+    make build-forge-patch
 ```
 
 This command will place the patched `forge` binary in `bin/forge`.
 
+**Building `solc`**
+
+Next, build the patched version of `solc` (this will also take a while):
+
+```
+make build-solc-patch
+```
+
 **Installing `huffc`**
+
+The [`huff`] version of the `EIP-3074` invoker requires `huffc` to be installed.
 
 ```sh
 make install-huff
@@ -30,9 +42,10 @@ make install-huff
 **Running Examples**
 
 To run the examples, interact with the patched `forge` binary as normal. There is a special override for the `Prague` hardfork within the `foundry.toml` which
-will enable the `AUTH` & `AUTHCALL` opcodes.
+will enable the `AUTH` & `AUTHCALL` opcodes, and the `foundry.toml` specifies the patched `solc` binary as the compiler.
 
 [foundry]: https://github.com/foundry-rs/foundry
 [revm]: https://github.com/bluealloy/revm
 [ethers-rs]: https://github.com/gakonst/ethers-rs
 [eip-3074]: https://eips.ethereum.org/EIPS/eip-3074
+[solc]: https://github.com/ethereum/solidity

--- a/foundry.toml
+++ b/foundry.toml
@@ -8,6 +8,7 @@ remappings = [
   "forge-std/=lib/forge-std/src/",
   "solady/=lib/solady/src/",
 ]
+solc = "bin/solc"
 
 [fmt]
 bracket_spacing = true


### PR DESCRIPTION
## Overview

Adds a custom version of the Solidity compiler that experimentally supports EIP-3074.

### Supports

**New Address Member Fn - `authcall`**
```solidity
address(0xBEEFbabe).authcall(hex"");
```

**Inline ASM**
```solidity
assembly {
    // AUTH invocation
    let success := auth(..., ..., ...)

    // AUTHCALL invocation
    let success := authcall(..., ..., ..., ..., ..., ..., ..., ...)
}
```