### PR TITLE
update contracts for spec changes

### DIFF
--- a/script/Execute.s.sol
+++ b/script/Execute.s.sol
@@ -10,7 +10,7 @@ contract Executor is Script {
 
     function signAndExecute(address invoker, bytes memory execData) public {
         // construct the digest from execData
-        bytes32 digest = BaseInvoker(invoker).getDigest(execData);
+        bytes32 digest = BaseInvoker(invoker).getDigest(vm.getNonce(vm.addr(pk)), execData);
         // sign the digest
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
         // broadcast execute transaction

--- a/src/Auth.sol
+++ b/src/Auth.sol
@@ -12,7 +12,7 @@ abstract contract Auth is BaseAuth {
 
     /// @notice call AUTH opcode with a given a commitment + signature
     /// @param commit - any 32-byte value used to commit to transaction validity conditions
-    /// @dev (v, r, s) are interpreted as an ECDSA signature on the secp256k1 curve over getDigest(commit)
+    /// @dev (v, r, s) are interpreted as an ECDSA signature on the secp256k1 curve over getDigest(nonce, commit)
     /// @custom:reverts BadAuth() if  AUTH fails due to invalid signature
     function auth(address authority, bytes32 commit, uint8 v, bytes32 r, bytes32 s) internal {
         bool success = authSimple(authority, commit, v, r, s);

--- a/src/BaseAuth.sol
+++ b/src/BaseAuth.sol
@@ -8,6 +8,7 @@ abstract contract BaseAuth {
     uint8 constant MAGIC = 0x04;
 
     /// @notice produce a digest for the authorizer to sign
+    /// @param nonce - the current transaction nonce of the signing authority
     /// @param commit - any 32-byte value used to commit to transaction validity conditions
     /// @return digest - sign the `digest` to authorize the invoker to execute the `calls`
     /// @dev signing `digest` authorizes this contact to execute code on behalf of the signer
@@ -16,9 +17,10 @@ abstract contract BaseAuth {
     ///      the Invoker logic MUST implement constraints on the contract execution based on information in the `commit`;
     ///      otherwise, any EOA that signs an AUTH for the Invoker will be compromised
     /// @dev per EIP-3074, digest = keccak256(MAGIC || chainId || paddedInvokerAddress || commit)
-    function getDigest(bytes32 commit) public view returns (bytes32 digest) {
-        digest =
-            keccak256(abi.encodePacked(MAGIC, bytes32(block.chainid), bytes32(uint256(uint160(address(this)))), commit));
+    function getDigest(uint256 nonce, bytes32 commit) public view returns (bytes32 digest) {
+        digest = keccak256(
+            abi.encodePacked(MAGIC, bytes32(block.chainid), nonce, bytes32(uint256(uint160(address(this)))), commit)
+        );
     }
 
     function authSimple(address authority, bytes32 commit, uint8 v, bytes32 r, bytes32 s)

--- a/src/BaseInvoker.sol
+++ b/src/BaseInvoker.sol
@@ -9,9 +9,6 @@ import { MultiSendAuthCallOnly } from "src/MultiSendAuthCallOnly.sol";
 /// @notice Shared functionality for Invoker contracts to efficiently AUTH a signer, then execute arbitrary application logic.
 /// @dev To implement an Invoker contract, simply inherit BaseInvoker and override the exec function with your Invoker logic.
 abstract contract BaseInvoker is Auth {
-    /// @notice thrown when `execute` finishes with leftover value in the Invoker contract, which is unsafe as it could be spent by anyone
-    error ExtraValue();
-
     /// @notice produce a digest to sign that authorizes the invoker
     ///         to execute actions using AUTHCALL
     /// @param nonce - the current transaction nonce of the signing authority
@@ -34,8 +31,6 @@ abstract contract BaseInvoker is Auth {
         auth(authority, keccak256(execData), v, r, s);
         // execute Invoker operations, which may use AUTHCALL
         exec(authority, execData);
-        // ensure that all value passed to the transaction was passed on to sub-calls (no leftover value in invoker)
-        if (address(this).balance != 0) revert ExtraValue();
     }
 
     /// @notice override `exec` to implement Invoker-specific application logic

--- a/src/BaseInvoker.sol
+++ b/src/BaseInvoker.sol
@@ -14,12 +14,13 @@ abstract contract BaseInvoker is Auth {
 
     /// @notice produce a digest to sign that authorizes the invoker
     ///         to execute actions using AUTHCALL
+    /// @param nonce - the current transaction nonce of the signing authority
     /// @param execData - packed bytes containing invoker-specific execution logic
     /// @dev keccak256 hash of execData is used as the commit for AUTH
     /// @return digest - the payload that the authority should sign
     ///         in order to authorize the specific execData using AUTHCALL
-    function getDigest(bytes memory execData) external view returns (bytes32 digest) {
-        digest = getDigest(keccak256(execData));
+    function getDigest(uint256 nonce, bytes memory execData) external view returns (bytes32 digest) {
+        digest = getDigest(nonce, keccak256(execData));
     }
 
     /// @notice execute some action(s) on behalf of a signing authority using AUTH and AUTHCALL

--- a/test/Auth.t.sol
+++ b/test/Auth.t.sol
@@ -37,7 +37,7 @@ contract AuthTest is Test {
     function test_auth_success() external {
         vm.pauseGasMetering();
         bytes32 commit = keccak256("eip-3074 4ever");
-        bytes32 digest = target.getDigest(commit);
+        bytes32 digest = target.getDigest(vm.getNonce(vm.addr(authority.privateKey)), commit);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(authority.privateKey, digest);
         vm.resumeGasMetering();
         bool success = target.authSimpleHarness(authority.addr, commit, v, r, s);
@@ -49,7 +49,7 @@ contract AuthTest is Test {
         vm.pauseGasMetering();
         // sign digest for `commit`
         bytes32 commit = keccak256("eip-3074 4ever");
-        bytes32 digest = target.getDigest(commit);
+        bytes32 digest = target.getDigest(vm.getNonce(vm.addr(authority.privateKey)), commit);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(authority.privateKey, digest);
         // pass `wrongCommit` with signature over `commit`
         bytes32 wrongCommit = keccak256("abstraction h8er");
@@ -65,7 +65,7 @@ contract AuthTest is Test {
             privateKey > 0
                 && privateKey < 115792089237316195423570985008687907852837564279074904382605163141518161494337
         );
-        bytes32 digest = target.getDigest(commit);
+        bytes32 digest = target.getDigest(vm.getNonce(vm.addr(authority.privateKey)), commit);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
         address authrty = vm.addr(privateKey);
         vm.resumeGasMetering();
@@ -78,7 +78,7 @@ contract AuthTest is Test {
         vm.pauseGasMetering();
         // sign digest for `commit`
         bytes32 commit = keccak256("eip-3074 4ever");
-        bytes32 digest = target.getDigest(commit);
+        bytes32 digest = target.getDigest(vm.getNonce(vm.addr(authority.privateKey)), commit);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(authority.privateKey, digest);
         // pass `wrongCommit` with signature over `commit`
         bytes32 wrongCommit = keccak256("abstraction h8er");

--- a/test/BatchInvoker.t.sol
+++ b/test/BatchInvoker.t.sol
@@ -42,7 +42,7 @@ contract BatchInvokerTest is Test {
         bytes memory transactions = abi.encodePacked(AUTHCALL_IDENTIFIER, address(callee), value, data.length, data);
         execData = abi.encode(nonce, transactions);
         // construct batch digest & sign
-        bytes32 digest = invoker.getDigest(execData);
+        bytes32 digest = invoker.getDigest(vm.getNonce(vm.addr(authority.privateKey)), execData);
         (v, r, s) = vm.sign(authority.privateKey, digest);
     }
 


### PR DESCRIPTION
Two spec updates have happened:
- `value` is now pulled from authority account 
- authority `nonce` was added into AUTH signature digest

This PR updates the Invoker contracts to reflect spec changes. 